### PR TITLE
Remove admin dashboard panels

### DIFF
--- a/README.md
+++ b/README.md
@@ -25,6 +25,7 @@ All features are activated by default when the plugin is activated.
 - Disable XML RPC for security
 - Disables comments feeds
 - Disables feeds
+- Removes *WordPress Events & News panel* from Dashboard
 - Remove contributor, subscriber and author roles
 - Remove Gutenberg's front-end block styles
 - Removes ?ver= query from styles and scripts

--- a/headache.php
+++ b/headache.php
@@ -122,6 +122,14 @@ function headache_login_title(): string
 
 add_filter('login_headertext', 'headache_login_title');
 
+// Remove admin dashboard panels.
+function headache_remove_dashboard_panels(): void
+{
+    remove_meta_box('dashboard_primary', 'dashboard', 'side');
+}
+
+add_action('wp_dashboard_setup', 'headache_remove_dashboard_panels');
+
 // Remove Gutenberg's front-end block styles.
 function headache_remove_block_styles()
 {


### PR DESCRIPTION
This PR removes the *WordPress Events & News* panel from the Dashboard.

![image](https://user-images.githubusercontent.com/1066486/136556883-a91aea9b-cd2b-4cca-b41a-2d2c815926a3.png)

Don't know how opinionated you want this plugin to be, but I would personally also remove the *Quick Draft* panel.
Let me know if you'd want that as well, and I'll push a new commit. 👍

```diff
function headache_remove_dashboard_panels(): void
{
    remove_meta_box('dashboard_primary', 'dashboard', 'side');
+   remove_meta_box('dashboard_quick_press', 'dashboard', 'side');
}
```

![image](https://user-images.githubusercontent.com/1066486/136556941-025b3a18-d47c-409d-a819-d86242f428c1.png)
