### PR TITLE
Add required header for Git Updater to work

### DIFF
--- a/headache.php
+++ b/headache.php
@@ -14,6 +14,7 @@
  * Author URI: https://github.com/wordplate/wordplate
  * Version: 1.3.0
  * Plugin URI: https://github.com/wordplate/headache
+ * GitHub Plugin URI: wordplate/headache
  */
 
 // Redirects all feeds to home page.


### PR DESCRIPTION
Adds `GitHub Plugin URI: wordplate/headache` to the plugin header, so this plugin can receive automatic updates from the Git Updater plugin.