### PR TITLE
Further restrict XML RPC

### DIFF
--- a/headache.php
+++ b/headache.php
@@ -42,6 +42,7 @@ add_filter('login_display_language_dropdown', '__return_false');
 
 // Disable XML RPC for security.
 add_filter('xmlrpc_enabled', '__return_false');
+add_filter('xmlrpc_methods', '__return_false');
 
 // Removes WordPress version.
 remove_action('wp_head', 'wp_generator');


### PR DESCRIPTION
This will result in an error message, but that's better than leaving it open imo.

```
$ curl -d '<methodCall><methodName>demo.sayHello</methodName></methodCall>' https://localhost/wordpress/xmlrpc.php -k
<?xml version="1.0" encoding="UTF-8"?>
<methodResponse>
  <fault>
    <value>
      <struct>
        <member>
          <name>faultCode</name>
          <value><int>-32601</int></value>
        </member>
        <member>
          <name>faultString</name>
          <value><string>server error. requested method demo.sayHello does not exist.</string></value>
        </member>
      </struct>
    </value>
  </fault>
</methodResponse>
```

Source: https://www.scottbrownconsulting.com/2020/03/two-ways-to-fully-disable-wordpress-xml-rpc/